### PR TITLE
Migrate to BDS colors

### DIFF
--- a/app/src/main/java/org/buffer/android/components/RoundedButton.kt
+++ b/app/src/main/java/org/buffer/android/components/RoundedButton.kt
@@ -6,6 +6,7 @@ import android.graphics.Typeface
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.AppCompatButton
 import android.util.AttributeSet
+import android.view.Gravity.CENTER
 import android.view.Gravity.CENTER_HORIZONTAL
 
 class RoundedButton @JvmOverloads constructor(
@@ -16,7 +17,7 @@ class RoundedButton @JvmOverloads constructor(
 
     init {
         setBackground(attrs)
-        gravity = CENTER_HORIZONTAL
+        gravity = CENTER
         isClickable = true
         typeface = Typeface.DEFAULT_BOLD
     }

--- a/app/src/main/java/org/buffer/android/components/RoundedButton.kt
+++ b/app/src/main/java/org/buffer/android/components/RoundedButton.kt
@@ -7,7 +7,6 @@ import android.support.v4.content.ContextCompat
 import android.support.v7.widget.AppCompatButton
 import android.util.AttributeSet
 import android.view.Gravity.CENTER
-import android.view.Gravity.CENTER_HORIZONTAL
 
 class RoundedButton @JvmOverloads constructor(
         context: Context,

--- a/app/src/main/res/color/selector_clear_button_text.xml
+++ b/app/src/main/res/color/selector_clear_button_text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:color="@color/disabled_text" />
-    <item android:color="@color/grey_text"/>
+    <item android:state_enabled="false" android:color="@color/text_disabled" />
+    <item android:color="@color/gray_dark"/>
 </selector>

--- a/app/src/main/res/color/selector_dark_button_text.xml
+++ b/app/src/main/res/color/selector_dark_button_text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:color="@color/disabled_text" />
+    <item android:state_enabled="false" android:color="@color/text_disabled" />
     <item android:color="@color/white"/>
 </selector>

--- a/app/src/main/res/color/selector_light_button_text.xml
+++ b/app/src/main/res/color/selector_light_button_text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:color="@color/disabled_text" />
+    <item android:state_enabled="false" android:color="@color/text_disabled" />
     <item android:color="@color/white"/>
 </selector>

--- a/app/src/main/res/drawable/button_bfr_round_clear_disabled.xml
+++ b/app/src/main/res/drawable/button_bfr_round_clear_disabled.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="@dimen/corner_radius" />
-    <solid android:color="@color/misty_grey" />
+    <solid android:color="@color/gray" />
 </shape>

--- a/app/src/main/res/drawable/button_bfr_round_clear_pressed.xml
+++ b/app/src/main/res/drawable/button_bfr_round_clear_pressed.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="@dimen/corner_radius" />
-    <solid android:color="@color/light_grey" />
+    <solid android:color="@color/gray_light" />
 </shape>

--- a/app/src/main/res/drawable/button_bfr_round_dark_disabled.xml
+++ b/app/src/main/res/drawable/button_bfr_round_dark_disabled.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="@dimen/corner_radius" />
-    <solid android:color="@color/misty_grey" />
+    <solid android:color="@color/gray" />
 </shape>

--- a/app/src/main/res/drawable/button_bfr_round_dark_pressed.xml
+++ b/app/src/main/res/drawable/button_bfr_round_dark_pressed.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="@dimen/corner_radius" />
-    <solid android:color="@color/sidebar_blue_light" />
+    <solid android:color="@color/gray_dark" />
 </shape>

--- a/app/src/main/res/drawable/button_bfr_round_dark_unfocused.xml
+++ b/app/src/main/res/drawable/button_bfr_round_dark_unfocused.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="@dimen/corner_radius" />
-    <solid android:color="@color/outer_space" />
+    <solid android:color="@color/gray_darker" />
 </shape>

--- a/app/src/main/res/drawable/button_bfr_round_light_disabled.xml
+++ b/app/src/main/res/drawable/button_bfr_round_light_disabled.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="@dimen/corner_radius" />
-    <solid android:color="@color/misty_grey" />
+    <solid android:color="@color/gray" />
 </shape>

--- a/app/src/main/res/layout/view_item_selection_message_sheet.xml
+++ b/app/src/main/res/layout/view_item_selection_message_sheet.xml
@@ -18,7 +18,7 @@
         android:layout_marginEnd="16dp"
         android:layout_marginRight="16dp"
         android:layout_marginBottom="16dp"
-        android:textColor="@color/outer_space"
+        android:textColor="@color/text_primary"
         android:textSize="@dimen/text_title"
         android:textStyle="bold"
         tools:text="@tools:sample/lorem" />
@@ -32,7 +32,7 @@
         android:layout_marginEnd="16dp"
         android:layout_marginRight="16dp"
         android:layout_marginBottom="16dp"
-        android:textColor="@color/outer_space"
+        android:textColor="@color/text_primary"
         android:textSize="@dimen/text_body"
         tools:text="@tools:sample/lorem" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,34 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="colorPrimary">@color/white</color>
-    <color name="colorPrimaryDark">@color/denim</color>
+    <color name="colorPrimaryDark">@color/curious_blue_dark</color>
     <color name="colorAccent">@color/curious_blue</color>
 
-    <color name="white">#ffffff</color>
-    <color name="off_white">#F4F7F9</color>
-    <color name="curious_blue">#004CFF</color>
-    <color name="curious_blue_dark">#0143DE</color>
-    <color name="curious_blue_light">#55AAEC</color>
-    <color name="sidebar_blue">#192534</color>
-    <color name="sidebar_blue_light">#384E69</color>
-    <color name="denim">#0f63a4</color>
-    <color name="aqua_haze">#f4f7f9</color>
-    <color name="geyser">#ced7df</color>
-    <color name="nevada">#666c72</color>
-    <color name="solid_gray">#E9EAED</color>
-    <color name="light_shuttle_gray">#F0F0F0</color>
-    <color name="shuttle_gray">#59626a</color>
-    <color name="outer_space">#323b43</color>
-    <color name="torch_red">#ff1e1e</color>
-    <color name="misty_grey">#BDBDBD</color>
+    <color name="curious_blue">@color/blue</color>
+    <color name="curious_blue_dark">@color/blue_dark</color>
+    <color name="curious_blue_light">@color/blue_light</color>
 
     <color name="black">#000000</color>
-    <color name="light_grey">#ECECEC</color>
-    <color name="grey_text">#636363</color>
-
-    <color name="title_text">#000000</color>
-    <color name="content_text">#6B6B6B</color>
-    <color name="disabled_text">#77797A</color>
+    <color name="white">#ffffff</color>
 
     <!--BDS colors-->
 


### PR DESCRIPTION
Delete any colors not in the Buffer Design System.

It is expected that if our apps are using any colors not in BDS, they will have them defined within the app themselves.

This required changing some of the colors in the app. Most of them were very small changes in color to make them adapt to BDS. The biggest change is the dark button, which I worked with @annchichi to make sure the colors I picked looked good.

![20190730_165632](https://user-images.githubusercontent.com/9600190/62168390-102db380-b2eb-11e9-9243-879222659e40.gif)

Sidenote: I made a sample app for displaying the components. I can push it up separately so it can be used to test any changes before it's uploaded.