### PR TITLE
Rework input dialog

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,13 +4,15 @@ apply plugin: 'kotlin-android'
 
 apply plugin: 'kotlin-android-extensions'
 
-apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'maven-publish'
+
+apply plugin: 'com.jfrog.bintray'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 30
     }
     buildTypes {
         release {
@@ -26,19 +28,55 @@ android {
 
 dependencies {
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0'
-    implementation 'com.github.bufferapp:CounterView:115e659a89'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 }
 
-publish {
-    repoName = 'Maven'
-    userOrg = 'buffer'
-    groupId = 'org.buffer.android'
-    artifactId = 'android-components'
-    publishVersion = '1.4'
-    desc = 'An Android library for frequently used UI components'
-    website = 'https://github.com/bufferapp/android-components'
+def getKey(String key) {
+    def Properties props = new Properties()
+    props.load(new FileInputStream(file('../local.properties')))
+    return props[key]
 }
 
+publishing {
+    publications {
+        Production(MavenPublication) {
+            artifact("$buildDir/outputs/aar/app-release.aar")
+            groupId 'org.buffer.android'
+            artifactId 'android-components'
+            version this.version
+
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+
+                // Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+                configurations.implementation.allDependencies.each {
+                    // Ensure dependencies such as fileTree are not included in the pom.
+                    if (it.name != 'unspecified') {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+            }
+        }
+    }
+}
+
+bintray {
+    user = getKey("BINTRAY_USER")
+    key = getKey("BINTRAY_KEY")
+    pkg {
+        repo = 'Maven'
+        name = 'android-components'
+        userOrg = 'buffer'
+        vcsUrl = 'https://github.com/bufferapp/android-components'
+        version {
+            name = '1.6'
+            released  = new Date()
+            vcsTag = '1.6'
+        }
+    }
+}

--- a/app/src/main/java/org/buffer/android/components/DialogFactory.kt
+++ b/app/src/main/java/org/buffer/android/components/DialogFactory.kt
@@ -14,14 +14,13 @@ import android.widget.EditText
 import android.widget.ImageView
 import android.widget.TextView
 
-import org.buffer.android.counterview.CounterView
-
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputLayout
 import kotlinx.android.synthetic.main.dialog_whats_new.view.*
 
 object DialogFactory {
@@ -343,26 +342,24 @@ object DialogFactory {
     }
 
     fun showLimitedLengthInputDialog(
-            context: Context, maxLength: Int,
-            @StringRes titleResource: Int,
-            @StringRes messageResource: Int,
-            @StringRes positive: Int,
-            @StringRes negative: Int,
-            inputListener: InputListener? = null,
-            defaultText: String? = null
+        context: Context,
+        maxLength: Int,
+        titleResource: String,
+        messageResource: String,
+        positive: String,
+        negative: String,
+        inputListener: InputListener? = null,
+        defaultText: String? = null
     ): AlertDialog {
         val builder = MaterialAlertDialogBuilder(context)
-                .setTitle(titleResource)
-                .setMessage(messageResource)
+            .setTitle(titleResource)
+            .setMessage(messageResource)
 
         val layout = LayoutInflater.from(context)
                 .inflate(R.layout.view_limited_length_input, null)
         val editText = layout.findViewById<EditText>(R.id.input)
-        val counterView = layout.findViewById<CounterView>(R.id.view_counter)
+        val inputLayout = layout.findViewById<TextInputLayout>(R.id.textContainer)
         if (defaultText != null) editText.setText(defaultText)
-        counterView.charactersRemainingUntilCounterDisplay = (maxLength * 0.15).toInt()
-        counterView.counterMaxLength = maxLength
-        counterView.attachToEditText(editText)
 
         builder.setView(layout)
                 .setPositiveButton(positive) { _, _ ->
@@ -371,14 +368,20 @@ object DialogFactory {
                 .setNegativeButton(negative) { dialog, _ -> dialog.cancel() }
         val dialog = builder.create()
         editText.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {
-                dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled =
-                        editText.text.length <= maxLength
-            }
+            override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
 
             override fun onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
 
-            override fun afterTextChanged(editable: Editable) {}
+            override fun afterTextChanged(editable: Editable) {
+                val hasTextWithinAllowedLimit = editText.text.length <= maxLength
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = hasTextWithinAllowedLimit
+                if (!hasTextWithinAllowedLimit) {
+                    inputLayout.error = context.getString(
+                        R.string.error_message_input_dialog, maxLength)
+                } else {
+                    inputLayout.error = null
+                }
+            }
         })
         return dialog
     }

--- a/app/src/main/res/layout/view_limited_length_input.xml
+++ b/app/src/main/res/layout/view_limited_length_input.xml
@@ -8,22 +8,21 @@
     android:paddingStart="16dp"
     android:paddingEnd="16dp">
 
-    <com.google.android.material.textfield.TextInputEditText
-        android:id="@+id/input"
-        style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/textContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:importantForAutofill="no"
-        android:inputType="textMultiLine"
-        tools:text="@tools:sample/lorem/random" />
+        app:boxBackgroundColor="?colorSurface"
+        app:errorEnabled="true">
 
-    <org.buffer.android.counterview.CounterView
-        android:id="@+id/view_counter"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end"
-        app:counterErrorTextColor="@color/red"
-        app:counterMode="descending"
-        app:counterCountColor="?colorAccent"
-        tools:text="260" />
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:importantForAutofill="no"
+            android:inputType="textMultiLine"
+            tools:text="@tools:sample/lorem/random" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
     <string name="dialog_dont_ask_again">Don\'t ask again.</string>
 
     <string name="dialog_action_ok">OK</string>
+
+    <string name="error_message_input_dialog">Content cannot be more than %d characters</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.10'
     repositories {
         google()
         maven { url 'https://maven.fabric.io/public' }
@@ -10,10 +10,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.novoda:bintray-release:0.9.1'
-
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 12 15:48:19 GMT 2020
+#Tue Aug 04 17:14:15 BST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,14 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
-
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "org.buffer.android.components.sample"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -28,10 +26,10 @@ android {
 dependencies {
     implementation project(':app')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.core:core-ktx:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.2.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/sample/src/main/java/org/buffer/android/components/sample/MainActivity.kt
+++ b/sample/src/main/java/org/buffer/android/components/sample/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import kotlinx.android.synthetic.main.activity_main.*
 import org.buffer.android.components.BottomSheetFactory
+import org.buffer.android.components.DialogFactory
 
 class MainActivity : AppCompatActivity() {
     lateinit var reminderBottomSheet: BottomSheetDialog
@@ -29,6 +30,17 @@ class MainActivity : AppCompatActivity() {
                     })
 
             reminderBottomSheet.show()
+        }
+
+        textInputButton.setOnClickListener {
+            DialogFactory.showLimitedLengthInputDialog(
+                this,
+                10,
+                "Title",
+                "Message",
+                "OK",
+                "Cancel"
+            ).show()
         }
     }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,21 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".MainActivity">
 
     <org.buffer.android.components.RoundedButton
+        android:id="@+id/click_me_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/click_me_button"
-        android:text="Click Me!"
         android:enabled="true"
-        app:bufferButtonStyle="light"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:text="Click Me!"
+        app:bufferButtonStyle="light" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <org.buffer.android.components.RoundedButton
+        android:id="@+id/textInputButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:enabled="true"
+        android:text="Text Input Dialog"
+        app:bufferButtonStyle="light" />
+
+</LinearLayout>


### PR DESCRIPTION
Reworks the input dialog so that the TextInput is correctly displayed.

I also needed to update the bintray publishing approach, as the previous plugin does not work with the latest android studio.